### PR TITLE
Add tags for search

### DIFF
--- a/src/renderer/components/ProjectDetail.jsx
+++ b/src/renderer/components/ProjectDetail.jsx
@@ -68,7 +68,7 @@ export class ProjectDetail extends React.Component {
       });
     });
     const allTag = _allTag.filter((x, i, self) => {
-      return self.indexOf(x) === self.lastIndexOf(x);
+      return self.indexOf(x) === i;
     });
 
     const relatedProjects = (

--- a/src/renderer/utils/WebAPIUtils.js
+++ b/src/renderer/utils/WebAPIUtils.js
@@ -262,11 +262,20 @@ class Server {
 
   async updateProject(project) {
     debug('updateProject', project);
+    const _allTag = [];
+    project.content.map(content => {
+      content.figure.step_tags.map(tag => {
+        _allTag.push(String(tag.step_tag));
+      });
+    });
+    const allTag = _allTag.filter((x, i, self) => {
+      return self.indexOf(x) === i;
+    });
     const data = {
       project: {
         name: project.name,
         description: project.description,
-        tag_list: project.tag_list.join(','),
+        tag_list: allTag.join(','),
         private: project.private,
         content_attributes: {
           figures_attributes: project.figures.map(figure => {


### PR DESCRIPTION
ユーザには表示しないが，全体のタグ情報（figures tagを含む）を重複無しで `tags` に追加できるようにした．これで従来のfabnavi APIでの探索が可能になる